### PR TITLE
Added GoogleTest and tested ResourceManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.vs/
 *.sln
 *.vcxproj
 *.vcxproj.*
+Blokus.slnLaunch.user
 
 **/Debug
 **/Release
@@ -11,7 +13,7 @@
 
 **/include
 **/packages
-**/BlokusTests
+packages.config
 
 ui_design/
 

--- a/BlokusTest/core_test.cc
+++ b/BlokusTest/core_test.cc
@@ -1,0 +1,29 @@
+#include "pch.h"
+#include "../Blokus/ResourceManager.h"
+#include <memory>
+#include <SFML/Graphics.hpp>
+
+namespace core_test {
+    TEST(ResourceManagerTest, WindowPtrTest) {
+        ResourceManager rm;
+        const std::unique_ptr<sf::RenderWindow>& rm_window_ptr = rm.getWindowPtr();
+        const std::unique_ptr<sf::RenderWindow>& null_ptr = nullptr;
+
+        ASSERT_NE(nullptr, rm_window_ptr);
+        ASSERT_NE(null_ptr, rm_window_ptr);
+        EXPECT_NO_THROW(rm_window_ptr->clear(sf::Color::Black));
+        EXPECT_NO_THROW(rm_window_ptr->display());
+    }
+
+    TEST(ResourceManagerTest, FontTest) {
+        ResourceManager rm;
+        const sf::Font &font = rm.getFont();
+
+        EXPECT_NO_THROW(sf::Text text(font));
+    }
+
+    
+    
+
+}
+    

--- a/BlokusTest/pch.cpp
+++ b/BlokusTest/pch.cpp
@@ -1,0 +1,5 @@
+//
+// pch.cpp
+//
+
+#include "pch.h"

--- a/BlokusTest/pch.h
+++ b/BlokusTest/pch.h
@@ -1,0 +1,7 @@
+//
+// pch.h
+//
+
+#pragma once
+
+#include "gtest/gtest.h"


### PR DESCRIPTION
## Adding [GoogleTest](https://google.github.io/googletest/)
### Setup
- Instead of using CMake, I am sticking with Visual Studio 2022.

- To add GoogleTest to Visual Studio 2022, follow the directions [here](https://learn.microsoft.com/en-us/visualstudio/test/how-to-use-google-test-for-cpp?view=vs-2019)

- To resolve Linker error (eg. LNK2019), follow the directions [here](https://learn.microsoft.com/en-us/visualstudio/test/writing-unit-tests-for-c-cpp?view=vs-2019#basic-test-workflow)

### Specific Setup Instructions
- In Project BlokusTest's Property, Linker -> General, add `$(SolutionDir)Blokus\Debug`
 
- In Project BlokusTest's Property, Linker -> Input,  include the following without `main.obj`
```
$(SolutionDir)Blokus\Debug\GameEngine.obj
$(SolutionDir)Blokus\Debug\ResourceManager.obj
$(SolutionDir)Blokus\Debug\GameScene.obj
$(SolutionDir)Blokus\Debug\MenuScene.obj
$(SolutionDir)Blokus\Debug\SettingsScene.obj
$(SolutionDir)Blokus\Debug\Scene.obj
$(SolutionDir)Blokus\Debug\Sidebar.obj
```


- Then, repeat the same steps as the SFML setup in BlokusTest

- Make sure that the SFML libraries are added to Linker Input (erase -d for Release)
```
sfml-window-d.lib
sfml-system-d.lib
sfml-graphics-d.lib
sfml-audio-d.lib
sfml-network-d.lib
```

- Make sure that you are running both projects with x86 by clicking BlokusTest in the Solution Explorer, going to Configure Startup Projects, going to Configuration Property and changing everything to Win32

### Unit tested ResourceManager (all successful)